### PR TITLE
Corrected the name of the azCli parameter name in the FormattedParametersSummary

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -265,7 +265,7 @@ namespace LightIngest
 
             esb.AppendLine($"Connection string          : {ConnectionString}");
             if (!string.IsNullOrWhiteSpace(ConnectWithManagedIdentity)) { esb.AppendLine($"-managedIdentity           : {ConnectWithManagedIdentity}"); }
-            if(ConnectWithAzCli) { esb.AppendLine($"-az_cli                    : {ConnectWithAzCli}"); }
+            if(ConnectWithAzCli) { esb.AppendLine($"-azCli                    : {ConnectWithAzCli}"); }
 
             esb.AppendLine($"-database                  : {DatabaseName}");
             esb.AppendLine($"-table                     : {TableName}");


### PR DESCRIPTION
Corrected the name of the azCli parameter name in the FormattedParametersSummary.

Fix for issue #16 